### PR TITLE
bump dfu-core version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "dfu-core"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b82ffc1790e4af9371dbc3399c6c068a3ee506357632e21eb7111df199c59f3"
+checksum = "00fab7382221c801db4853a1ff338bb1281e8f2f9b456e888793fef61c4d890c"
 dependencies = [
  "bytes",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["dfu", "libusb"]
 
 [dependencies]
-dfu-core = { version = "0.2", features = ["std"] }
+dfu-core = { version = "0.2.1", features = ["std"] }
 libusb1-sys = "0.6"
 rusb = "0.9"
 thiserror = "1"


### PR DESCRIPTION
If you could create a release, I could use the `download_from_slice` function in `cargo-dfu`, which would help resolve the issue: https://github.com/dfu-rs/cargo-dfu/issues/4 I think. 