### PR TITLE
fix: release usb interface before reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -103,15 +103,15 @@ dependencies = [
 
 [[package]]
 name = "dfu-core"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324d7b4a076182d0cd50ec0f10b49c2d9c1dc13c0071dbf7510733c6f394b256"
+checksum = "37d22eb1608d4e74a04cfee0ac99c9b6e7ef9ed509b9c6e1caf54510c171ee1a"
 dependencies = [
  "bytes",
  "displaydoc",
  "log",
  "pretty-hex",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -124,7 +124,7 @@ dependencies = [
  "indicatif",
  "rusb",
  "simplelog",
- "thiserror",
+ "thiserror 1.0.31",
 ]
 
 [[package]]
@@ -261,9 +261,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "pretty-hex"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+checksum = "9a65843dfefbafd3c879c683306959a6de478443ffe9c9adf02f5976432402d7"
 
 [[package]]
 name = "proc-macro-error"
@@ -402,7 +402,16 @@ version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.31",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -414,6 +423,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.98",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 keywords = ["dfu", "libusb"]
 
 [dependencies]
-dfu-core = { version = "0.9", features = ["std"] }
+dfu-core = { version = "0.11", features = ["std"] }
 rusb = "0.9"
 thiserror = "1"
 

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -113,24 +113,26 @@ impl Cli {
             device.override_address(address);
         }
 
-        match device.download(file, file_size) {
-            Ok(_) => (),
+        let device = match device.download(file, file_size) {
+            Ok(d) => d,
             Err(Error::LibUsb(..)) if bar.is_finished() => {
                 println!("USB error after upload; Device reset itself?");
                 return Ok(());
             }
-            e => return e.context("could not write firmware to the device"),
-        }
+            Err(e) => return Err(e).context("could not write firmware to the device"),
+        };
 
         if reset {
-            // Detach isn't strictly meant to be sent after a download, however u-boot in
-            // particular will only switch to the downloaded firmware if it saw a detach before
-            // a usb reset. So send a detach blindly...
-            //
-            // This matches the behaviour of dfu-util so should be safe
-            let _ = device.detach();
-            println!("Resetting device");
-            device.usb_reset()?;
+            if let Some(mut d) = device {
+                // Detach isn't strictly meant to be sent after a download, however u-boot in
+                // particular will only switch to the downloaded firmware if it saw a detach before
+                // a usb reset. So send a detach blindly...
+                //
+                // This matches the behaviour of dfu-util so should be safe
+                let _ = d.detach();
+                println!("Resetting device");
+                d.usb_reset()?;
+            }
         }
 
         Ok(())

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -123,7 +123,7 @@ impl Cli {
         };
 
         if reset {
-            if let Some(mut d) = device {
+            if let Some(d) = device {
                 // Detach isn't strictly meant to be sent after a download, however u-boot in
                 // particular will only switch to the downloaded firmware if it saw a detach before
                 // a usb reset. So send a detach blindly...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::marker;
 use thiserror::Error;
 
-pub type Dfu<C> = dfu_core::sync::DfuSync<DfuLibusb<C>, Error>;
+pub type Dfu<C> = dfu_core::synchronous::DfuSync<DfuLibusb<C>, Error>;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -163,7 +163,7 @@ impl<C: rusb::UsbContext> DfuLibusb<C> {
                     marker: marker::PhantomData,
                 };
 
-                return Ok(dfu_core::sync::DfuSync::new(io));
+                return Ok(Dfu::new(io));
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,15 @@ impl<C: rusb::UsbContext> dfu_core::DfuIo for DfuLibusb<C> {
         Ok(res?)
     }
 
-    fn usb_reset(&self) -> Result<Self::Reset, Self::Error> {
-        Ok(self.usb.borrow_mut().reset()?)
+    fn usb_reset(self) -> Result<Self::Reset, Self::Error> {
+        // Release the interface before resetting the device. On macOS,
+        // libusb's reset fails if an interface is still claimed. Explicitly
+        // releasing here (rather than relying on DeviceHandle's Drop) makes
+        // the intent clear and ensures the interface is released before the
+        // reset call.
+        let mut handle = self.usb.into_inner();
+        handle.release_interface(self.iface as u8)?;
+        Ok(handle.reset()?)
     }
 
     fn protocol(&self) -> &dfu_core::DfuProtocol<Self::MemoryLayout> {


### PR DESCRIPTION
Bump dfu-core from 0.9 to 0.11 and fix USB reset on macOS by explicitly
releasing the claimed interface before calling reset.

On macOS, libusb's `reset()` fails when an interface is still claimed.
The previous implementation relied on `DeviceHandle`'s `Drop` impl to
release the interface, but that runs after reset has already been attempted.
This change makes `usb_reset` consume `self`, calls `release_interface`
explicitly, then resets.

The dfu-core 0.11 bump also changes the `download()` return type to hand
back the device on success (or `None` if the device reset itself during
the transfer), so the reset/detach path in the example is now gated on
receiving the device back.

Related to https://github.com/dfu-rs/dfu-nusb/pull/13