### PR TITLE
fix: handle missing interface strings correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,11 +150,10 @@ impl<C: rusb::UsbContext> DfuLibusb<C> {
                     .find(|x| x.setting_number() == alt)
                     .ok_or(Error::InvalidAlt)?;
 
-                let interface_string =
-                    match iface_desc.description_string_index() {
-                        None => String::new(),
-                        Some(_) => handle.read_interface_string(*lang, &iface_desc, timeout)?,
-                    };
+                let interface_string = match iface_desc.description_string_index() {
+                    None => String::new(),
+                    Some(_) => handle.read_interface_string(*lang, &iface_desc, timeout)?,
+                };
                 let protocol = dfu_core::DfuProtocol::new(
                     &interface_string,
                     functional_descriptor.dfu_version,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,12 @@ impl<C: rusb::UsbContext> DfuLibusb<C> {
                     .find(|x| x.setting_number() == alt)
                     .ok_or(Error::InvalidAlt)?;
 
-                let interface_string = handle.read_interface_string(*lang, &iface_desc, timeout)?;
+                let interface_string =
+                    match handle.read_interface_string(*lang, &iface_desc, timeout) {
+                        Ok(interface_string) => interface_string,
+                        Err(rusb::Error::InvalidParam) => String::new(),
+                        Err(err) => return Err(err.into()),
+                    };
                 let protocol = dfu_core::DfuProtocol::new(
                     &interface_string,
                     functional_descriptor.dfu_version,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,10 +151,9 @@ impl<C: rusb::UsbContext> DfuLibusb<C> {
                     .ok_or(Error::InvalidAlt)?;
 
                 let interface_string =
-                    match handle.read_interface_string(*lang, &iface_desc, timeout) {
-                        Ok(interface_string) => interface_string,
-                        Err(rusb::Error::InvalidParam) => String::new(),
-                        Err(err) => return Err(err.into()),
+                    match iface_desc.description_string_index() {
+                        None => String::new(),
+                        Some(_) => handle.read_interface_string(*lang, &iface_desc, timeout)?,
                     };
                 let protocol = dfu_core::DfuProtocol::new(
                     &interface_string,


### PR DESCRIPTION
Seems like I found a small bug. In the current implementation dfu-devices without interface string descriptor are rejected due to an early return statement.